### PR TITLE
Feature/update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,15 @@
     <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.source>8</maven.compiler.source>
 
-    <io.jsonwebtoken.jjwt.version>0.11.2</io.jsonwebtoken.jjwt.version>
+    <io.jsonwebtoken.jjwt.version>0.12.3</io.jsonwebtoken.jjwt.version>
 
-    <junit.jupiter.version>5.8.2</junit.jupiter.version>
-    <assertj.core.version>3.22.0</assertj.core.version>
-    <mockito.core.version>4.3.1</mockito.core.version>
-    <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
+    <junit.jupiter.version>5.10.1</junit.jupiter.version>
+    <assertj.core.version>3.24.2</assertj.core.version>
+    <mockito.core.version>4.11.0</mockito.core.version>
+    <spotbugs.annotations.version>4.8.2</spotbugs.annotations.version>
 
-    <maven.sonatype.ossindex.plugin.version>3.1.0</maven.sonatype.ossindex.plugin.version>
-    <maven.spotbugs.plugin.version>4.5.3.0</maven.spotbugs.plugin.version>
+    <maven.sonatype.ossindex.plugin.version>3.2.0</maven.sonatype.ossindex.plugin.version>
+    <maven.spotbugs.plugin.version>4.8.2.0</maven.spotbugs.plugin.version>
     <maven.spotbugs.security.plugin.version>1.11.0</maven.spotbugs.security.plugin.version>
     <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
   </properties>
@@ -76,23 +76,29 @@
 
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>${findbugs.annotations.version}</version>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>${spotbugs.annotations.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.41.4</version>
+      <version>1.43.3</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-gson</artifactId>
-      <version>1.41.4</version>
+      <version>1.43.3</version>
     </dependency>
 
+    <!-- Enforcing version 32.1.3-jre for guava to address vulnerability (CVE-2023-2976) in previous versions -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.3-jre</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/github/onsdigital/SigningKeyLocatorImpl.java
+++ b/src/main/java/com/github/onsdigital/SigningKeyLocatorImpl.java
@@ -1,9 +1,8 @@
 package com.github.onsdigital;
 
 import com.github.onsdigital.exceptions.JWTDecodeException;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwsHeader;
-import io.jsonwebtoken.SigningKeyResolverAdapter;
+import io.jsonwebtoken.LocatorAdapter;
 
 import java.security.Key;
 import java.security.KeyFactory;
@@ -16,10 +15,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A {@link SigningKeyResolverAdapter} implementation for determining the correct, configured signing key to use based
+ * A {@link LocatorAdapter} implementation for determining the correct, configured signing key to use based
  * on the 'kid' field in a JWT header.
  */
-public final class SigningKeyResolverImpl extends SigningKeyResolverAdapter {
+public final class SigningKeyLocatorImpl extends LocatorAdapter<Key> {
 
     static final String KEYS_REQUIRED_ERROR = "Public signing keys are required";
     static final String PUBLIC_KEY_CHECK_ERROR = "Public key check failed: ";
@@ -29,11 +28,11 @@ public final class SigningKeyResolverImpl extends SigningKeyResolverAdapter {
     private final Map<String, Key> signingKeys;
 
     /**
-     * Construct a new {@link SigningKeyResolverImpl}.
+     * Construct a new {@link SigningKeyLocatorImpl}.
      *
      * @param signingKeys the {@link Map} of key IDs to base 64 encoded, DER formatted public signing keys
      */
-    public SigningKeyResolverImpl(Map<String, String> signingKeys) {
+    public SigningKeyLocatorImpl(Map<String, String> signingKeys) {
         if (signingKeys == null || signingKeys.isEmpty()) {
             throw new IllegalArgumentException(KEYS_REQUIRED_ERROR);
         }
@@ -56,16 +55,15 @@ public final class SigningKeyResolverImpl extends SigningKeyResolverAdapter {
     }
 
     /**
-     * Returns the signing key that should be used to validate a digital signature for the Claims JWS with the specified
-     * header and claims.
+     * Returns the signing key that should be used to validate a digital signature for the JWS with the specified
+     * header.
      *
      * @param jwsHeader the header of the JWS to validate
-     * @param claims    the claims (body) of the JWS to validate
-     * @return the signing key that should be used to validate a digital signature for the Claims JWS with the specified
-     * header and claims.
+     * @return the signing key that should be used to validate a digital signature for the JWS with the specified
+     * header.
      */
     @Override
-    public Key resolveSigningKey(JwsHeader jwsHeader, Claims claims) {
+    public Key locate(JwsHeader jwsHeader) {
         Key key = signingKeys.get(jwsHeader.getKeyId());
         if (key == null) {
             throw new JWTDecodeException(PUBLIC_KEY_ERROR);

--- a/src/test/java/com/github/onsdigital/JWTVerifierImplTests.java
+++ b/src/test/java/com/github/onsdigital/JWTVerifierImplTests.java
@@ -72,7 +72,7 @@ class JWTVerifierImplTests {
     void verify_ShouldThrowException_WhenKeyIDUnknown() {
         assertThatThrownBy(() -> verifier.verify(INVALID_KID_TOKEN))
                 .isInstanceOf(JWTDecodeException.class)
-                .hasMessageContaining(SigningKeyResolverImpl.PUBLIC_KEY_ERROR);
+                .hasMessageContaining(SigningKeyLocatorImpl.PUBLIC_KEY_ERROR);
     }
 
     @Test
@@ -112,14 +112,14 @@ class JWTVerifierImplTests {
     void verify_ShouldThrowException_WhenJWTNull() {
         assertThatThrownBy(() -> verifier.verify(null))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("JWT String argument cannot be null or empty.");
+                .hasMessageContaining("CharSequence cannot be null or empty.");
     }
 
     @Test
     void verify_ShouldThrowException_WhenJWTEmpty() {
         assertThatThrownBy(() -> verifier.verify(""))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("JWT String argument cannot be null or empty.");
+                .hasMessageContaining("CharSequence cannot be null or empty.");
     }
 
     @Test

--- a/src/test/java/com/github/onsdigital/SigningKeyLocatorImplTests.java
+++ b/src/test/java/com/github/onsdigital/SigningKeyLocatorImplTests.java
@@ -1,9 +1,8 @@
 package com.github.onsdigital;
 
 import com.github.onsdigital.exceptions.JWTDecodeException;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwsHeader;
-import io.jsonwebtoken.SigningKeyResolver;
+import io.jsonwebtoken.Locator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -18,14 +17,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-class SigningKeyResolverImplTests {
+class SigningKeyLocatorImplTests {
 
     private final static String PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwdowpUQS8YPrzFamOi7bEM74+yeqoAH0Tm+PLZdWjaIxL13XfxX63jO3iHAJe/Uh74d2vtTuHV7Vkl0wRjjJOuWrj5espG5VxU6xHJG/R2tVDElv05fFZhZn/YCwUJV2Zrz9Z0PIdPHB4eZODo64Qfab+ihgeLlny5l6+srVacWqsQ47i3DdJQOd6MgacvrKt+B0Ior1HKlHR0NneFPNu9zvCg11O1W0yl2+ou0UOPVqF8EfoavvgwbAUWwxeHXcN+TmgKx6Oa4X9ylk+Q0FUewYF020f5j7AW9EZrdu4rBTO2fliV02+DblOh/NTuHEzeCBHp3h4Mg5Bv3NYxY9sQIDAQAB";
 
     private final static String PUBLIC_KEY_ID = "1234example=";
 
     @Mock
-    private JwsHeader<?> jwsHeader;
+    private JwsHeader jwsHeader;
 
     @BeforeEach
     void beforeEach() {
@@ -34,25 +33,25 @@ class SigningKeyResolverImplTests {
 
     @Test
     void constructor_ShouldThrowException_WhenNullSigningKeys() {
-        assertThatThrownBy(() -> new SigningKeyResolverImpl(null))
+        assertThatThrownBy(() -> new SigningKeyLocatorImpl(null))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(SigningKeyResolverImpl.KEYS_REQUIRED_ERROR);
+                .hasMessageContaining(SigningKeyLocatorImpl.KEYS_REQUIRED_ERROR);
     }
 
     @Test
     void constructor_ShouldThrowException_WhenNotValidKeyFormat() {
         Map<String, String> signingKeys = new HashMap<>();
         signingKeys.put("1234", "SU5WQUxJRF9LRVk=");
-        assertThatThrownBy(() -> new SigningKeyResolverImpl(signingKeys))
+        assertThatThrownBy(() -> new SigningKeyLocatorImpl(signingKeys))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(SigningKeyResolverImpl.PUBLIC_KEY_CHECK_ERROR);
+                .hasMessageContaining(SigningKeyLocatorImpl.PUBLIC_KEY_CHECK_ERROR);
     }
 
     @Test
     void constructor_ShouldThrowException_WhenKeyNotBase64() {
         Map<String, String> signingKeys = new HashMap<>();
         signingKeys.put("1234", "INVALID_KEY");
-        assertThatThrownBy(() -> new SigningKeyResolverImpl(signingKeys))
+        assertThatThrownBy(() -> new SigningKeyLocatorImpl(signingKeys))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Illegal base64 character");
     }
@@ -61,11 +60,11 @@ class SigningKeyResolverImplTests {
     void resolveSigningKey_ShouldReturnKey_WhenKeyIDKnown() {
         Map<String, String> signingKeys = new HashMap<>();
         signingKeys.put(PUBLIC_KEY_ID, PUBLIC_KEY);
-        SigningKeyResolver signingKeyResolver = new SigningKeyResolverImpl(signingKeys);
+        Locator<Key> keyLocator = new SigningKeyLocatorImpl(signingKeys);
 
         when(jwsHeader.getKeyId()).thenReturn(PUBLIC_KEY_ID);
 
-        Key result = signingKeyResolver.resolveSigningKey(jwsHeader , (Claims) null);
+        Key result = keyLocator.locate(jwsHeader);
 
         assertNotNull(result);
         assertEquals("RSA", result.getAlgorithm());
@@ -75,25 +74,25 @@ class SigningKeyResolverImplTests {
     void resolveSigningKey_ShouldThrowException_WhenKeyIDNotKnown() {
         Map<String, String> signingKeys = new HashMap<>();
         signingKeys.put(PUBLIC_KEY_ID, PUBLIC_KEY);
-        SigningKeyResolver signingKeyResolver = new SigningKeyResolverImpl(signingKeys);
+        Locator<Key> keyLocator = new SigningKeyLocatorImpl(signingKeys);
 
         when(jwsHeader.getKeyId()).thenReturn("unknown_key_id");
 
-        assertThatThrownBy(() -> signingKeyResolver.resolveSigningKey(jwsHeader , (Claims) null))
+        assertThatThrownBy(() -> keyLocator.locate(jwsHeader))
                 .isInstanceOf(JWTDecodeException.class)
-                .hasMessageContaining(SigningKeyResolverImpl.PUBLIC_KEY_ERROR);
+                .hasMessageContaining(SigningKeyLocatorImpl.PUBLIC_KEY_ERROR);
     }
 
     @Test
     void resolveSigningKey_ShouldThrowException_WhenKeyIDNull() {
         Map<String, String> signingKeys = new HashMap<>();
         signingKeys.put(PUBLIC_KEY_ID, PUBLIC_KEY);
-        SigningKeyResolver signingKeyResolver = new SigningKeyResolverImpl(signingKeys);
+        Locator<Key> keyLocator = new SigningKeyLocatorImpl(signingKeys);
 
         when(jwsHeader.getKeyId()).thenReturn(null);
 
-        assertThatThrownBy(() -> signingKeyResolver.resolveSigningKey(jwsHeader , (Claims) null))
+        assertThatThrownBy(() -> keyLocator.locate(jwsHeader))
                 .isInstanceOf(JWTDecodeException.class)
-                .hasMessageContaining(SigningKeyResolverImpl.PUBLIC_KEY_ERROR);
+                .hasMessageContaining(SigningKeyLocatorImpl.PUBLIC_KEY_ERROR);
     }
 }


### PR DESCRIPTION
### What
Update all dependencies to their latest minor version. Certain classes and functions used in this repository from `io.jsonwebtoken.jjwt.version `dependency have been deprecated. Below are the deprecated functions with the changes made to reflect those upgrades:

- [SigningKeyResolver](https://github.com/jwtk/jjwt/blob/master/api/src/main/java/io/jsonwebtoken/SigningKeyResolver.java#L52) -> _various Resolver concepts have been unified into a single [Locator](https://github.com/jwtk/jjwt/blob/master/api/src/main/java/io/jsonwebtoken/Locator.java) interface_
- [resolveSigningKey(JwsHeader header, Claims claims)](https://github.com/jwtk/jjwt/blob/master/api/src/main/java/io/jsonwebtoken/SigningKeyResolverAdapter.java#L67) -> [locate(JwsHeader header)](https://github.com/jwtk/jjwt/blob/master/api/src/main/java/io/jsonwebtoken/LocatorAdapter.java#L48) 
- [SigningKeyResolverAdapter](url)  -> [LocatorAdapter](https://github.com/jwtk/jjwt/blob/master/api/src/main/java/io/jsonwebtoken/LocatorAdapter.java#L29) 
- [parseClaimJws(CharSequence jws)](https://github.com/jwtk/jjwt/blob/master/api/src/main/java/io/jsonwebtoken/JwtParser.java#L204) -> [parseSignedClaims(CharSequence jws)](https://github.com/jwtk/jjwt/blob/master/api/src/main/java/io/jsonwebtoken/JwtParser.java#L331)

The library [google-http-client](https://mvnrepository.com/artifact/com.google.http-client/google-http-client) has a dependency on [com.google.guava](https://mvnrepository.com/artifact/com.google.guava/guava) but it's using an older version of it that has vulnerabilities and it's causing the audit stage of the pipeline to fail. The latest version of com.google.guava [32.1.3-jre](https://mvnrepository.com/artifact/com.google.guava/guava/32.1.3-jre) is enforced to fix this.

To stop [spotbugs-maven-plugin](https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-maven-plugin) from throwing a [CT_CONSTRUCTOR_THROW](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html) error the JWTVerifierImpl has been defined ad a final class.

[com.google.code.findbugs](https://mvnrepository.com/artifact/com.google.code.findbugs) » findbugs-annotations artifact was moved to [com.github.spotbugs](https://mvnrepository.com/artifact/com.github.spotbugs) » [spotbugs-annotations](https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations)

### How to review
Checkout branch locally. Ensure you are on JDK 8 version and run the tests. 
No dependencies or plugins should require upgrades.
More info on how to run the tests and how to check for dependency upgrades can be found [here].(https://confluence.ons.gov.uk/display/DIS/Java+repositories)
### Who can review
A member of ONS